### PR TITLE
Un-archiving Cassandra snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cassandra_*.snap

--- a/common
+++ b/common
@@ -39,6 +39,7 @@ case $(arch) in
         exit 1
         ;;
 esac
-export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-"$ARCH"/jre/bin/java
+export JAVA_VERSION=11
+export JAVA="$SNAP"/usr/lib/jvm/java-"$JAVA_VERSION"-openjdk-"$ARCH"/bin/java
 export CASSANDRA_INCLUDE=
-export JAVA_VERSION=8
+export CASSANDRA_USE_JDK11=true

--- a/common
+++ b/common
@@ -21,24 +21,7 @@ done
 
 export CLASSPATH
 
-case $(arch) in
-    x86_64)
-        export ARCH=amd64
-        ;;
-    aarch64)
-        export ARCH=arm64
-        ;;
-    ppc64le)
-        export ARCH=ppc64el
-        ;;
-    s390x)
-        export ARCH=s390x
-        ;;
-    *)
-        echo "Unsupported architecture $(arch)"
-        exit 1
-        ;;
-esac
+export ARCH=$(dpkg --print-architecture)
 export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-"$ARCH"/jre/bin/java
 export CASSANDRA_INCLUDE=
 export JAVA_VERSION=8

--- a/common
+++ b/common
@@ -39,7 +39,6 @@ case $(arch) in
         exit 1
         ;;
 esac
-export JAVA_VERSION=11
-export JAVA="$SNAP"/usr/lib/jvm/java-"$JAVA_VERSION"-openjdk-"$ARCH"/bin/java
+export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-"$ARCH"/jre/bin/java
 export CASSANDRA_INCLUDE=
-export CASSANDRA_USE_JDK11=true
+export JAVA_VERSION=8

--- a/common
+++ b/common
@@ -21,7 +21,24 @@ done
 
 export CLASSPATH
 
-# TODO: use arch to define ARCH
-export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+case $(arch) in
+    x86_64)
+        export ARCH=amd64
+        ;;
+    aarch64)
+        export ARCH=arm64
+        ;;
+    ppc64le)
+        export ARCH=ppc64el
+        ;;
+    s390x)
+        export ARCH=s390x
+        ;;
+    *)
+        echo "Unsupported architecture $(arch)"
+        exit 1
+        ;;
+esac
+export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-"$ARCH"/jre/bin/java
 export CASSANDRA_INCLUDE=
 export JAVA_VERSION=8

--- a/common
+++ b/common
@@ -20,3 +20,8 @@ for jar in $SNAP/usr/share/cassandra/lib/*.jar; do
 done
 
 export CLASSPATH
+
+# TODO: use arch to define ARCH
+export JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+export CASSANDRA_INCLUDE=
+export JAVA_VERSION=8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,7 @@ parts:
             </settings>
             EOF
             fi
+            mkdir -p $HOME/.ant
             cp $HOME/.m2/settings.xml $HOME/.ant/settings.xml
             echo "Installed settings.xml:"
             cat $HOME/.m2/settings.xml settings.xml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,10 +58,10 @@ parts:
             if [ -n ${http_proxy} -a -n ${https_proxy} ]; then
                 mkdir -p $HOME/.m2
                 http_port=$(echo $http_proxy | rev | cut -d':' -f 1 | rev)
-                http_host=$(echo $http_proxy | sed "s/:${http_port}$//")
+                http_host=$(echo $http_proxy | sed "s;:${http_port}$;;")
                 http_port=$(echo $http_port | sed 's;/;;g')
                 https_port=$(echo $https_proxy | rev | cut -d':' -f 1 | rev)
-                https_host=$(echo $https_proxy | sed "s/:${https_port}$//")
+                https_host=$(echo $https_proxy | sed "s;:${https_port}$;;")
                 https_port=$(echo $https_port | sed 's;/;;g')
                 cat << EOF > $HOME/.m2/settings.xml
             <settings>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,8 @@ parts:
                 # remove http(s):// from hosts
                 http_host=$(echo $http_host | sed 's;^https\?://;;')
                 https_host=$(echo $https_host | sed 's;^https\?://;;')
+                non_proxy_hosts=$(echo $no_proxy | sed -e 's;https\?://;;g' -e 's/\s*,\s*/|/g')
+                non_proxy_hosts=${non_proxy_hosts:=localhost}
                 cat << EOF > $HOME/.m2/settings.xml
             <?xml version="1.0" encoding="UTF-8"?>
             <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
@@ -79,6 +81,7 @@ parts:
                   <protocol>http</protocol>
                   <host>${http_host}</host>
                   <port>${http_port}</port>
+                  <nonProxyHosts>${non_proxy_hosts}</nonProxyHosts>
                 </proxy>
                <proxy>
                   <id>launchpad-proxy-https</id>
@@ -86,6 +89,7 @@ parts:
                   <protocol>https</protocol>
                   <host>${https_host}</host>
                   <port>${https_port}</port>
+                  <nonProxyHosts>${non_proxy_hosts}</nonProxyHosts>
                 </proxy>
               </proxies>
             </settings>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: cassandra
-version: latest
-version-script: git -C parts/cassandra/build describe --tags | sed 's/cassandra-//'
+# Set the version during the build based on a tag name
+adopt-info: cassandra
+base: core18
 summary: Manage massive amounts of data, fast, without losing sleep
 description: |
   The Apache Cassandra database is the right choice when you need
@@ -11,8 +12,8 @@ description: |
   best-in-class, providing lower latency for your users and the peace of
   mind of knowing that you can survive regional outages.
 
-confinement: strict
-grade: stable
+confinement: devmode
+grade: devel
 
 apps:
     cassandra:
@@ -52,7 +53,9 @@ parts:
             - artifacts
         source: https://github.com/apache/cassandra
         source-type: git
+        ant-openjdk-version: "8"
         override-build: |
+            candidate_version="latest"
             last_committed_tag="$(git describe --tags --abbrev=0)"
             last_committed_tag_ver="$(echo $last_committed_tag | sed 's/cassandra-//')"
             last_released_tag="$(snap info wethr | awk '$1 == "beta:" { print $2 }')"
@@ -61,7 +64,9 @@ parts:
             if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
               git fetch
               git checkout "${last_committed_tag}"
+              candidate_version="${last_committed_tag_ver}"
             fi
+            snapcraftctl set-version "${candidate_version}"
             snapcraftctl build
         build-packages:
             - ant-optional

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,13 +4,11 @@ adopt-info: cassandra
 base: core18
 summary: Manage massive amounts of data, fast, without losing sleep
 description: |
-  The Apache Cassandra database is the right choice when you need
-  scalability and high availability without compromising performance. Linear
-  scalability and proven fault-tolerance on commodity hardware or cloud
-  infrastructure make it the perfect platform for mission-critical
-  data.Cassandra's support for replicating across multiple datacenters is
-  best-in-class, providing lower latency for your users and the peace of
-  mind of knowing that you can survive regional outages.
+  Apache Cassandra is an open source NoSQL distributed database trusted by
+  thousands of companies for scalability and high availability without
+  compromising performance. Linear scalability and proven fault-tolerance on
+  commodity hardware or cloud infrastructure make it a good platform for
+  mission-critical data.
 
 confinement: devmode
 grade: devel

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
             mkdir -p $HOME/.ant
             cp $HOME/.m2/settings.xml $HOME/.ant/settings.xml
             echo "Installed settings.xml:"
-            cat $HOME/.m2/settings.xml settings.xml
+            cat $HOME/.m2/settings.xml
             # make sure we will use openjdk 8 for the build
             update-alternatives --set java $(update-alternatives --list java | grep 8-openjdk)
             candidate_version="latest"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,9 @@ parts:
                 https_port=$(echo $https_proxy | rev | cut -d':' -f 1 | rev)
                 https_host=$(echo $https_proxy | sed "s;:${https_port}$;;")
                 https_port=$(echo $https_port | sed 's;/;;g')
+                # remove http(s):// from hosts
+                http_host=$(echo $http_host | sed 's;^https\?://;;')
+                https_host=$(echo $https_host | sed 's;^https\?://;;')
                 cat << EOF > $HOME/.m2/settings.xml
             <?xml version="1.0" encoding="UTF-8"?>
             <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,9 +58,10 @@ parts:
             if [ -n ${http_proxy} -a -n ${https_proxy} ]; then
                 mkdir -p $HOME/.m2
                 http_port=$(echo $http_proxy | rev | cut -d':' -f 1 | rev)
-                http_host=$(echo $http_proxy | sed 's/:${http_port}$//')
+                http_port=$(echo $http_port | sed 's;/;;g')
+                http_host=$(echo $http_proxy | sed "s/:${http_port}$//")
                 https_port=$(echo $https_proxy | rev | cut -d':' -f 1 | rev)
-                https_host=$(echo $https_proxy | sed 's/:${https_port}$//')
+                https_host=$(echo $https_proxy | sed "s/:${https_port}$//")
                 cat << EOF > $HOME/.m2/settings.xml
             <settings>
               <proxies>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,11 +49,12 @@ parts:
         plugin: ant
         ant-properties:
             dist.dir: $SNAPCRAFT_PART_INSTALL
+            use.jdk11: true
         ant-build-targets:
             - artifacts
         source: https://github.com/apache/cassandra
         source-type: git
-        ant-openjdk-version: "8"
+        ant-openjdk-version: "11"
         override-build: |
             candidate_version="latest"
             last_committed_tag="$(git describe --tags --abbrev=0)"
@@ -73,6 +74,7 @@ parts:
             - build-essential
             - python
             - sed
+            - openjdk-11-jdk
         stage-packages:
             # Copy some packages into the stage directory to steal their
             # pre-built binaries.
@@ -95,6 +97,7 @@ parts:
             - usr/sbin/cassandra
             - usr/share/cassandra/lib/*.jar
             - usr/lib/jvm
+            - etc/java-11-openjdk
             # awk, grep, and free are needed by cassandra-env.sh
             - usr/bin/awk
             - bin/grep

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,10 +58,11 @@ parts:
             if [ -n ${http_proxy} -a -n ${https_proxy} ]; then
                 mkdir -p $HOME/.m2
                 http_port=$(echo $http_proxy | rev | cut -d':' -f 1 | rev)
-                http_port=$(echo $http_port | sed 's;/;;g')
                 http_host=$(echo $http_proxy | sed "s/:${http_port}$//")
+                http_port=$(echo $http_port | sed 's;/;;g')
                 https_port=$(echo $https_proxy | rev | cut -d':' -f 1 | rev)
                 https_host=$(echo $https_proxy | sed "s/:${https_port}$//")
+                https_port=$(echo $https_port | sed 's;/;;g')
                 cat << EOF > $HOME/.m2/settings.xml
             <settings>
               <proxies>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,10 @@ parts:
                 https_host=$(echo $https_proxy | sed "s;:${https_port}$;;")
                 https_port=$(echo $https_port | sed 's;/;;g')
                 cat << EOF > $HOME/.m2/settings.xml
-            <settings>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
               <proxies>
                <proxy>
                   <id>launchpad-proxy-http</id>
@@ -84,6 +87,9 @@ parts:
             </settings>
             EOF
             fi
+            cp $HOME/.m2/settings.xml $HOME/.ant/settings.xml
+            echo "Installed settings.xml:"
+            cat $HOME/.m2/settings.xml settings.xml
             # make sure we will use openjdk 8 for the build
             update-alternatives --set java $(update-alternatives --list java | grep 8-openjdk)
             candidate_version="latest"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,8 +90,6 @@ parts:
             </settings>
             EOF
             fi
-            mkdir -p $HOME/.ant
-            cp $HOME/.m2/settings.xml $HOME/.ant/settings.xml
             echo "Installed settings.xml:"
             cat $HOME/.m2/settings.xml
             # make sure we will use openjdk 8 for the build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,9 +92,9 @@ parts:
               </proxies>
             </settings>
             EOF
+                echo "Installed settings.xml:"
+                cat $HOME/.m2/settings.xml
             fi
-            echo "Installed settings.xml:"
-            cat $HOME/.m2/settings.xml
             # make sure we will use openjdk 8 for the build
             update-alternatives --set java $(update-alternatives --list java | grep 8-openjdk)
             candidate_version="latest"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   commodity hardware or cloud infrastructure make it a good platform for
   mission-critical data.
 
-confinement: devmode
+confinement: strict
 grade: devel
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,6 +108,9 @@ parts:
             fi
             snapcraftctl set-version "${candidate_version}"
             snapcraftctl build
+        override-stage: |
+            snapcraftctl stage
+            chmod +x usr/sbin/cassandra
         build-packages:
             - ant-optional
             - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,12 +49,11 @@ parts:
         plugin: ant
         ant-properties:
             dist.dir: $SNAPCRAFT_PART_INSTALL
-            use.jdk11: true
         ant-build-targets:
             - artifacts
         source: https://github.com/apache/cassandra
         source-type: git
-        ant-openjdk-version: "11"
+        ant-openjdk-version: "8"
         override-build: |
             candidate_version="latest"
             last_committed_tag="$(git describe --tags --abbrev=0)"
@@ -74,7 +73,6 @@ parts:
             - build-essential
             - python
             - sed
-            - openjdk-11-jdk
         stage-packages:
             # Copy some packages into the stage directory to steal their
             # pre-built binaries.
@@ -97,7 +95,6 @@ parts:
             - usr/sbin/cassandra
             - usr/share/cassandra/lib/*.jar
             - usr/lib/jvm
-            - etc/java-11-openjdk
             # awk, grep, and free are needed by cassandra-env.sh
             - usr/bin/awk
             - bin/grep

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,9 @@ parts:
         source-type: git
         ant-openjdk-version: "8"
         override-build: |
+            # Hacky trick to handle proxy settings for resolver-ant-tasks
+            # https://bugs.launchpad.net/launchpad-buildd/+bug/1702130
+            # https://maven.apache.org/resolver-ant-tasks/
             if [ -n ${http_proxy} -a -n ${https_proxy} ]; then
                 mkdir -p $HOME/.m2
                 http_port=$(echo $http_proxy | rev | cut -d':' -f 1 | rev)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,33 @@ parts:
         source-type: git
         ant-openjdk-version: "8"
         override-build: |
+            if [ -n ${http_proxy} -a -n ${https_proxy} ]; then
+                mkdir -p $HOME/.m2
+                http_port=$(echo $http_proxy | rev | cut -d':' -f 1 | rev)
+                http_host=$(echo $http_proxy | sed 's/:${http_port}$//')
+                https_port=$(echo $https_proxy | rev | cut -d':' -f 1 | rev)
+                https_host=$(echo $https_proxy | sed 's/:${https_port}$//')
+                cat << EOF > $HOME/.m2/settings.xml
+            <settings>
+              <proxies>
+               <proxy>
+                  <id>launchpad-proxy-http</id>
+                  <active>true</active>
+                  <protocol>http</protocol>
+                  <host>${http_host}</host>
+                  <port>${http_port}</port>
+                </proxy>
+               <proxy>
+                  <id>launchpad-proxy-https</id>
+                  <active>true</active>
+                  <protocol>https</protocol>
+                  <host>${https_host}</host>
+                  <port>${https_port}</port>
+                </proxy>
+              </proxies>
+            </settings>
+            EOF
+            fi
             # make sure we will use openjdk 8 for the build
             update-alternatives --set java $(update-alternatives --list java | grep 8-openjdk)
             candidate_version="latest"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,8 @@ parts:
         source-type: git
         ant-openjdk-version: "8"
         override-build: |
+            # make sure we will use openjdk 8 for the build
+            update-alternatives --set java $(update-alternatives --list java | grep 8-openjdk)
             candidate_version="latest"
             last_committed_tag="$(git describe --tags --abbrev=0)"
             last_committed_tag_ver="$(echo $last_committed_tag | sed 's/cassandra-//')"

--- a/wrapper-cassandra
+++ b/wrapper-cassandra
@@ -7,7 +7,7 @@
 [ -e "$CASSANDRA_DATA" ] || mkdir "$CASSANDRA_DATA"
 
 # Required config files. Use the default if one is not provided.
-for f in cassandra.yaml logback.xml cassandra-env.sh jvm-server.options jvm11-server.options jvm11-clients.options jvm-clients.options; do
+for f in cassandra.yaml logback.xml cassandra-env.sh jvm.options; do
     if [ ! -e "$CASSANDRA_CONF/$f" ]; then
         if [ "$f" = "cassandra-env.sh" ]; then
             # Libraries are in /usr/share/cassandra, not CASSANDRA_HOME

--- a/wrapper-cassandra
+++ b/wrapper-cassandra
@@ -7,7 +7,7 @@
 [ -e "$CASSANDRA_DATA" ] || mkdir "$CASSANDRA_DATA"
 
 # Required config files. Use the default if one is not provided.
-for f in cassandra.yaml logback.xml cassandra-env.sh jvm.options; do
+for f in cassandra.yaml logback.xml cassandra-env.sh jvm8-server.options; do
     if [ ! -e "$CASSANDRA_CONF/$f" ]; then
         if [ "$f" = "cassandra-env.sh" ]; then
             # Libraries are in /usr/share/cassandra, not CASSANDRA_HOME
@@ -20,7 +20,9 @@ for f in cassandra.yaml logback.xml cassandra-env.sh jvm.options; do
 done
 
 export cassandra_storagedir="$CASSANDRA_DATA"
-export JVM_OPTS="$JVM_OPTS -Dcassandra.config=file://$CASSANDRA_CONF/cassandra.yaml"
+export JNA_TMPDIR="$SNAP_DATA/tmp/JNA"
+mkdir -p $JNA_TMPDIR
+export JVM_OPTS="$JVM_OPTS -Dcassandra.config=file://$CASSANDRA_CONF/cassandra.yaml -Djna.tmpdir=$JNA_TMPDIR"
 
 # The -x bit isn't set on cassandra
 /bin/sh $SNAP/usr/sbin/cassandra -R -p "$CASSANDRA_HOME/cassandra.pid"

--- a/wrapper-cassandra
+++ b/wrapper-cassandra
@@ -7,7 +7,7 @@
 [ -e "$CASSANDRA_DATA" ] || mkdir "$CASSANDRA_DATA"
 
 # Required config files. Use the default if one is not provided.
-for f in cassandra.yaml logback.xml cassandra-env.sh jvm.options; do
+for f in cassandra.yaml logback.xml cassandra-env.sh jvm-server.options jvm11-server.options jvm11-clients.options jvm-clients.options; do
     if [ ! -e "$CASSANDRA_CONF/$f" ]; then
         if [ "$f" = "cassandra-env.sh" ]; then
             # Libraries are in /usr/share/cassandra, not CASSANDRA_HOME


### PR DESCRIPTION
This PR is part of the works to un-archive and re-publish the Cassandra snap.

More details on these efforts are available in the [snapcrafter' s forum](https://forum.snapcraft.io/t/pointers-to-cassandra-state-history/24216/3) and in the [Ubuntu server team discourse](https://discourse.ubuntu.com/t/cassandra-snap-and-oci-image-status/22461)

The most important changes in the PR include
* Update version to 4.0-rc1; this change is important due to the upstream change on the dependency resolver library being used.
* Changes to allow builds to be performed in launchpad, by properly setting the maven proxy options